### PR TITLE
Addition of main bower option

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "carousel-3d",
   "version": "0.2.2",
+  "main": "dist/jquery.carousel-3d.js",
   "authors": [{
     "name": "PAIO co.,Ltd.",
     "email": "apple@paio.co.kr",


### PR DESCRIPTION
Addition of main option allows tools and plugins such as wiredep to automatically inject the library. See:
https://github.com/taptapship/wiredep
