### PR TITLE
Fix modernizr compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,14 +17,14 @@
   ],
   "dependencies": {
     "jquery": ">=1.9",
-    "modernizr": "latest",
+    "modernizr": "~2.8",
     "waitForImages": "latest",
     "javascript-detect-element-resize": "latest"
   },
   "devDependencies": {
     "qunit": "~1.12.0",
     "jquery": "~1.9",
-    "modernizr": "latest",
+    "modernizr": "~2.8",
     "waitForImages": "latest"
   },
   "homepage": "https://github.com/PAIO-CO-KR/carousel-3d",


### PR DESCRIPTION
Issue #23 

Not compatible with the latest version of modernizr, currently downloads v3.3.1
Changed the version to ~2.8 so carousel will work again.
